### PR TITLE
42 is not always the answer :(

### DIFF
--- a/contravariant-extras.cabal
+++ b/contravariant-extras.cabal
@@ -26,8 +26,8 @@ library
     Contravariant.Extras.ContrazipLifting
     Contravariant.Extras.Op
     Contravariant.Extras.Op.Contrazip
-  other-modules:
     Contravariant.Extras.TH
+  other-modules:
     Contravariant.Extras.Prelude
   build-depends:
     base >=4.10 && <5,


### PR DESCRIPTION
Hi, 

I have a table with 127 fields, and in order to encode all those suckers to use it with `hasql` I had to generate contrazip127. 

You have hidden TH submodule, and I had a need to use for it, hence other people might too, hence this PR. :) 

